### PR TITLE
Stop resource leakage when reading gunicorn file

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -37,11 +37,12 @@ def pytest_unconfigure(config):
 def start_gunicorn():
     global gunicorn
     gunicorn_log = open("reports/gunicorn.log", "ab")
-    gunicorn = subprocess.Popen(
-        ['gunicorn', 'navtest_wsgi:application'],
-        stdout=gunicorn_log,
-        stderr=subprocess.STDOUT,
-    )
+    with gunicorn_log:
+        gunicorn = subprocess.Popen(
+            ['gunicorn', 'navtest_wsgi:application'],
+            stdout=gunicorn_log,
+            stderr=subprocess.STDOUT,
+        )
 
 
 def stop_gunicorn():


### PR DESCRIPTION
As mentioned in my [comment on the PR](https://github.com/Uninett/nav/pull/2451#issuecomment-1198970026) there was still a resource warning in the functional tests, this should stop it.